### PR TITLE
Remove Midnight Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ A community-maintained list of Fluxer projects, libraries, utilities, and more.
 ## Tools
 
 - [fluxer-rpc](https://github.com/letruxux/fluxer-rpc) - mirror your discord rpc to fluxer! 〰️
-- [Midnight Tools](https://github.com/BubbaXM/Midnight-Tools/) - Custom add-on experience for Fluxer desktop, similar in spirit to Vencord-style customization for Discord clients
 - [BetterFluxer](https://github.com/RoxyBoxxy/BetterFluxer) - Plugin Injector for the Fluxer.app desktop client
 - [Reflux](https://github.com/Its3rr0rsWRLD/Reflux) - Simple plugin injector for Fluxer
 


### PR DESCRIPTION
Midnight Tools appears to include Fake Plutonium

This might be problematic especially since we have been linked in the official Fluxer Developers server

I have agreed with @mchaker to remove it, at least for the time being