### PR TITLE
add Reaper Tool (Discord -> Fluxer Migrator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ See [CONTRIBUTING.md](https://github.com/awesome-fluxer/awesome-fluxer/blob/main
 - [BetterFluxer](https://github.com/RoxyBoxxy/BetterFluxer) - Plugin Injector for the Fluxer.app desktop client
 - [Reflux](https://github.com/Its3rr0rsWRLD/Reflux) - Simple plugin injector for Fluxer
 - [Fluxbase](https://fluxbase.dev) - Your hub in the Fluxerverse to discover new bots or list your own for the community.
+- [Reaper Tool](https://github.com/rambros3d/disco-reaper) - Migrate your Discord Server to Fluxer, including complete message history.
 
 ## Bridges
 


### PR DESCRIPTION
**Reaper Tool** can migrate entire Discord Servers to Fluxer Community, including years & years of message history

Tool repo: https://github.com/rambros3d/disco-reaper

Support community: https://fluxer.gg/9KxDP8WH