### PR TITLE
Remove fluxer.world

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ See [CONTRIBUTING.md](https://github.com/awesome-fluxer/awesome-fluxer/blob/main
   - [Plugins](#plugins)
   - [Bridges](#bridges)
   - [Hosting](#hosting)
-  - [Instances](#instances)
   - [Self Hosting](#self-hosting)
     - [Self Hosting Guides](#self-hosting-guides)
     - [Self Hosting Resources](#self-hosting-resources)
@@ -137,10 +136,6 @@ See [CONTRIBUTING.md](https://github.com/awesome-fluxer/awesome-fluxer/blob/main
 
 ## Hosting
 - [fluxer.host](https://fluxer.host) - Free US/EU Hosting for Fluxer bots, bridges, and community tools.
-
-## Instances
-
-- [Fluxer World](https://fluxer.world/) - Community Fluxer instance
 
 ## Self Hosting
 


### PR DESCRIPTION
Remove fluxer.world as they supposedly make some shady claims (such as encryption, I assume), seem to vaguely come off as an official/unique software, and are outdated.
<img width="1401" height="494" alt="image" src="https://github.com/user-attachments/assets/70640228-87c6-4b3c-be9f-9edb63ab9508" />
https://fluxer.app/channels/1427764882469228556/1427764882469228559/1518391022009188352